### PR TITLE
Minor bug fixes including headers, shaders and macros.

### DIFF
--- a/Resources/Shaders/Bezier.geom
+++ b/Resources/Shaders/Bezier.geom
@@ -30,7 +30,7 @@ float factorial(int n)
 
     for (int i = 2; i <= n; ++i)
     {
-        result *= i;
+        result *= float(i);
     }
 
     return result;

--- a/Resources/Shaders/Color.geom
+++ b/Resources/Shaders/Color.geom
@@ -36,7 +36,7 @@ float factorial(int n)
     float result = 1;
 
     for (int i = 2; i <= n; ++i)
-        result *= i;
+        result *= float(i);
 
     return result;
 }

--- a/Resources/Shaders/CurveSelection.geom
+++ b/Resources/Shaders/CurveSelection.geom
@@ -28,7 +28,7 @@ float factorial(int n)
 
     for (int i = 2; i <= n; ++i)
     {
-        result *= i;
+        result *= float(i);
     }
 
     return result;

--- a/Source/Curve/Bezier.cpp
+++ b/Source/Curve/Bezier.cpp
@@ -287,7 +287,7 @@ float DiffusionCurveRenderer::Bezier::Factorial(int n) const
 
     for (int i = 1; i <= n; ++i)
     {
-        result *= i;
+        result *= float(i);
     }
 
     return result;

--- a/Source/Curve/Bezier.h
+++ b/Source/Curve/Bezier.h
@@ -6,7 +6,7 @@
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QObject>
-#include <Vector>
+#include <QVector>
 #include <memory>
 
 namespace DiffusionCurveRenderer

--- a/Source/Util/Logger.h
+++ b/Source/Util/Logger.h
@@ -63,27 +63,27 @@ namespace DiffusionCurveRenderer
     };
 }
 
-#define LOG_PRIVATE(LEVEL, FORMAT, ...)                                                   \
-    do                                                                                    \
-    {                                                                                     \
-        if (DiffusionCurveRenderer::Logger::isLogEnabledFor(LEVEL))                       \
-        {                                                                                 \
-            DiffusionCurveRenderer::Logger::Log(LEVEL, std::format(FORMAT, __VA_ARGS__)); \
-        }                                                                                 \
+#define LOG_PRIVATE(LEVEL, FORMAT, ...)                                                     \
+    do                                                                                      \
+    {                                                                                       \
+        if (DiffusionCurveRenderer::Logger::isLogEnabledFor(LEVEL))                         \
+        {                                                                                   \
+            DiffusionCurveRenderer::Logger::Log(LEVEL, std::format(FORMAT, ##__VA_ARGS__)); \
+        }                                                                                   \
     } while (false)
 
-#define LOG_TRACE(FORMAT, ...) LOG_PRIVATE(DiffusionCurveRenderer::LogLevel::TRACE, FORMAT, __VA_ARGS__)
-#define LOG_DEBUG(FORMAT, ...) LOG_PRIVATE(DiffusionCurveRenderer::LogLevel::DEBUG, FORMAT, __VA_ARGS__)
-#define LOG_INFO(FORMAT, ...)  LOG_PRIVATE(DiffusionCurveRenderer::LogLevel::INFO, FORMAT, __VA_ARGS__)
-#define LOG_WARN(FORMAT, ...)  LOG_PRIVATE(DiffusionCurveRenderer::LogLevel::WARNING, FORMAT, __VA_ARGS__)
-#define LOG_FATAL(FORMAT, ...) LOG_PRIVATE(DiffusionCurveRenderer::LogLevel::FATAL, FORMAT, __VA_ARGS__)
+#define LOG_TRACE(FORMAT, ...) LOG_PRIVATE(DiffusionCurveRenderer::LogLevel::TRACE, FORMAT, ##__VA_ARGS__)
+#define LOG_DEBUG(FORMAT, ...) LOG_PRIVATE(DiffusionCurveRenderer::LogLevel::DEBUG, FORMAT, ##__VA_ARGS__)
+#define LOG_INFO(FORMAT, ...)  LOG_PRIVATE(DiffusionCurveRenderer::LogLevel::INFO, FORMAT, ##__VA_ARGS__)
+#define LOG_WARN(FORMAT, ...)  LOG_PRIVATE(DiffusionCurveRenderer::LogLevel::WARNING, FORMAT, ##__VA_ARGS__)
+#define LOG_FATAL(FORMAT, ...) LOG_PRIVATE(DiffusionCurveRenderer::LogLevel::FATAL, FORMAT, ##__VA_ARGS__)
 
 #define DCR_ASSERT(EXPRESSION) assert(EXPRESSION)
 
-#define DCR_EXIT_FAILURE(FORMAT, ...)   \
-    do                                  \
-    {                                   \
-        LOG_FATAL(FORMAT, __VA_ARGS__); \
-        std::exit(EXIT_FAILURE);        \
-                                        \
+#define DCR_EXIT_FAILURE(FORMAT, ...)     \
+    do                                    \
+    {                                     \
+        LOG_FATAL(FORMAT, ##__VA_ARGS__); \
+        std::exit(EXIT_FAILURE);          \
+                                          \
     } while (false)


### PR DESCRIPTION
Hi, I am recently porting your code to Linux. When porting the code, I found a few unintended designs in your code, including:

* Line 9 of `Bezier.h` should be `#include <QVector>` instead of `#include <Vector>`, the reason why MSVC does not report this is that MSVC is not case sensitive.
* Shader compilers on Linux act slightly differently than those on Windows, as they are stricter in type conversions. I modified a few shaders to make them compile on Linux.
* Comma elision should be performed in variadic macros.

Although it can be compiled on Linux now, I still encounter runtime errors. I am still investigating this issue. However, I think the above improvements are still meaningful.

By the way, thank you very much for your code. Recently, Monte Carlo PDE research has become a hot topic in graphics, and Diffusion Curve happens to be one of its applications. A visual viewer is very useful.